### PR TITLE
Add frontend changes: dev mode, search results, about screen (component versions)

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -16,7 +16,9 @@ services:
       context: ./src/frontend
       args:
         BACKEND_API_ROOT: http://backend:8080/backend
+        ENVIRONMENT: development
     ports:
       - 8080:3000
     environment:
       - BACKEND_API_ROOT=http://backend:8080/backend
+      - ENVIRONMENT=development

--- a/src/frontend/Dockerfile
+++ b/src/frontend/Dockerfile
@@ -11,8 +11,13 @@ FROM node:16-alpine AS builder
 WORKDIR /app
 COPY . .
 COPY --from=deps /app/node_modules ./node_modules
+
 ARG BACKEND_API_ROOT
 ENV BACKEND_API_ROOT=${BACKEND_API_ROOT}
+
+ARG ENVIRONMENT
+ENV ENVIRONMENT=${ENVIRONMENT}
+
 RUN yarn build && yarn install --production --ignore-scripts --prefer-offline
 
 # Production image, copy all the files and run next

--- a/src/frontend/components/AboutModal.tsx
+++ b/src/frontend/components/AboutModal.tsx
@@ -1,0 +1,42 @@
+import { FRONTEND_VERSION } from '@lib/config';
+import { fetcher } from '@lib/fetcher';
+import React from 'react';
+import useSWR from 'swr/immutable';
+import Modal from './Modal';
+
+type AboutModalProps = {
+  open: boolean;
+  onClose: () => void;
+};
+
+type VersionResponse = {
+  error: any;
+  result?: {
+    backend: string;
+    nlp: string;
+  };
+};
+
+const VersionItem = ({ name, version }: { name: string; version?: string }) => (
+  <li>
+    {name}: {version}
+  </li>
+);
+
+const AboutModal = ({ open, onClose }: AboutModalProps) => {
+  const { data } = useSWR<VersionResponse>(`/api/version`, fetcher);
+
+  return (
+    <Modal title="About" onClose={onClose} open={open}>
+      <p className="font-bold">Versions:</p>
+
+      <ul className="">
+        <VersionItem name="Frontend" version={FRONTEND_VERSION} />
+        <VersionItem name="Backend" version={data?.result?.backend} />
+        <VersionItem name="NLP" version={data?.result?.nlp} />
+      </ul>
+    </Modal>
+  );
+};
+
+export default AboutModal;

--- a/src/frontend/components/ErrorMessage.tsx
+++ b/src/frontend/components/ErrorMessage.tsx
@@ -3,7 +3,7 @@ type Props = {
 };
 
 const ErrorMessage = ({ message }: Props) => {
-  return <p className="text-red-500 mb-2">{message}</p>;
+  return <p className="text-red-500 mb-2 whitespace-pre-wrap">{message}</p>;
 };
 
 export default ErrorMessage;

--- a/src/frontend/components/Layout.tsx
+++ b/src/frontend/components/Layout.tsx
@@ -1,0 +1,35 @@
+import Head from 'next/head';
+import React, { useState } from 'react';
+import AboutModal from './AboutModal';
+import Modal from './Modal';
+
+type LayoutProps = {
+  children: React.ReactNode;
+};
+
+const Layout = ({ children }: LayoutProps) => {
+  const [showAbout, setShowAbout] = useState(false);
+
+  return (
+    <>
+      <Head>
+        <title>Geo Data Search</title>
+      </Head>
+
+      <nav>
+        <button
+          className="absolute top-0 right-0 p-3 underline text-gray-600"
+          onClick={() => setShowAbout(true)}
+        >
+          About
+        </button>
+      </nav>
+
+      <main className="container max-w-xl w-full mx-auto my-12">{children}</main>
+
+      {showAbout && <AboutModal open={showAbout} onClose={() => setShowAbout(false)} />}
+    </>
+  );
+};
+
+export default Layout;

--- a/src/frontend/components/Modal.tsx
+++ b/src/frontend/components/Modal.tsx
@@ -1,0 +1,32 @@
+import { Dialog } from '@headlessui/react';
+import React from 'react';
+import { XIcon } from '@heroicons/react/outline';
+
+type Props = {
+  onClose: () => void;
+  open: boolean;
+  children: React.ReactNode;
+  title: string;
+};
+
+function Modal({ open, onClose, children, title }: Props) {
+  return (
+    <Dialog open={open} onClose={onClose} className="fixed z-10 inset-0 overflow-y-auto">
+      <div className="flex items-center justify-center min-h-screen">
+        <Dialog.Overlay className="fixed inset-0 bg-black opacity-30" />
+
+        <div className="relative bg-white rounded-lg max-w-lg w-full mx-auto p-6">
+          <button className='absolute top-0 right-0 p-2 hover:opacity-50' onClick={onClose}>
+            <XIcon className="h-8 w-8" />
+          </button>
+
+          <Dialog.Title className="font-bold text-2xl mb-4">{title}</Dialog.Title>
+
+          {children}
+        </div>
+      </div>
+    </Dialog>
+  );
+}
+
+export default Modal;

--- a/src/frontend/components/SearchInput.tsx
+++ b/src/frontend/components/SearchInput.tsx
@@ -13,7 +13,7 @@ const SearchInput = ({ value, onChange, placeholder }: Props) => {
 
   return (
     <input
-      className="border-solid border-gray-500 border rounded p-2"
+      className="border-solid border-gray-500 border rounded p-2 w-full"
       name="searchValue"
       type="text"
       placeholder={placeholder}

--- a/src/frontend/components/SearchListResult.tsx
+++ b/src/frontend/components/SearchListResult.tsx
@@ -1,0 +1,16 @@
+import { SearchResult } from '@lib/types/search';
+
+type Props = {
+  result: SearchResult;
+};
+
+const SearchListResult = ({ result }: Props) => {
+  return (
+    <li className="p-2 border-b-2 last:border-0">
+      <h3 className="font-bold">{result.name}</h3>
+      <p><span>{result.type}</span> · <span className='text-gray-500'>{result.lat}, {result.lon}</span></p>
+    </li>
+  );
+};
+
+export default SearchListResult;

--- a/src/frontend/components/SearchView.tsx
+++ b/src/frontend/components/SearchView.tsx
@@ -2,11 +2,13 @@ import React, { FormEvent, useState } from 'react';
 import apiClient from '@lib/api-client';
 import SearchInput from './SearchInput';
 import ErrorMessage from './ErrorMessage';
-import { SearchQueryResponse, SearchResult } from '@lib/types/search';
+import { SearchQueryResponse, SearchResult, SearchError } from '@lib/types/search';
+import SearchListResult from './SearchListResult';
+import { isDevelopment, sampleSearchResults } from '@lib/config';
 
 const SearchView = () => {
   const [searchValue, setSearchValue] = useState('');
-  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [errorData, setErrorData] = useState<SearchError | null>(null);
   const [results, setResults] = useState<SearchResult[] | null>(null);
   const [loading, setLoading] = useState(false);
 
@@ -15,41 +17,91 @@ const SearchView = () => {
 
     try {
       setLoading(true);
+      setErrorData(null);
+      setResults(null);
+
       const response = await apiClient('/user_query', {
         body: {
           query: searchValue,
         },
       });
+
       if (response.ok) {
         const { result, error }: SearchQueryResponse = await response.json();
+        console.log('Search result', result);
 
         if (error) {
-          setErrorMessage(error.message);
+          setErrorData(error);
         } else if (result) {
           setResults(result);
+        } else {
+          setErrorData({
+            type: 'system',
+            message: 'Got empty response from the API',
+          });
         }
       } else {
-        setErrorMessage('Looks like the server is down');
+        setErrorData({
+          type: 'client',
+          message: 'Looks like the server is down',
+          trace: new Error(`${response.status} ${response.statusText}`).stack,
+        });
       }
     } catch (err) {
       console.error('Search error', err);
-      setErrorMessage('Something went wrong, see console log for more info');
+      setErrorData({
+        type: 'client',
+        message: 'Something went wrong',
+        trace: new Error().stack,
+      });
     } finally {
       setLoading(false);
     }
   };
+
+  const searchTermEmpty = searchValue.trim().length === 0;
 
   return (
     <div className="my-8">
       <form onSubmit={getSearchSuggestions}>
         <div className="flex mb-4">
           <SearchInput placeholder="Search" value={searchValue} onChange={setSearchValue} />
-          <button className="bg-blue-500 text-white rounded px-5 ml-2" type="submit">
+          <button
+            className="bg-blue-500 text-white rounded px-5 ml-2 disabled:opacity-70 disabled:cursor-default"
+            type="submit"
+            disabled={searchTermEmpty}
+          >
             Submit
           </button>
+
+          <button
+            className="bg-yellow-500 text-white rounded px-5 ml-2 flex-shrink-0 disabled:opacity-70 disabled:cursor-default"
+            type="button"
+            disabled={searchTermEmpty}
+            onClick={() => {
+              setErrorData(null);
+              setResults(sampleSearchResults);
+            }}
+          >
+            Get fake results
+          </button>
         </div>
-        {results && results.length === 0 && <ErrorMessage message={'No results found'} />}
-        {errorMessage && <ErrorMessage message={errorMessage} />}
+
+        {results &&
+          (results.length > 0 ? (
+            <ul className="mt-8">
+              {sampleSearchResults.map((result) => (
+                <SearchListResult key={result.id} result={result} />
+              ))}
+            </ul>
+          ) : (
+            <p className="mb-2">No results found</p>
+          ))}
+
+        {errorData?.message && <ErrorMessage message={`Error: ${errorData.message}`} />}
+        {isDevelopment && errorData?.trace && (
+          <ErrorMessage message={`Trace: ${errorData.trace}`} />
+        )}
       </form>
     </div>
   );

--- a/src/frontend/lib/config.ts
+++ b/src/frontend/lib/config.ts
@@ -1,0 +1,28 @@
+import { SearchResult } from './types/search';
+
+export const isDevelopment = process.env.ENVIRONMENT === 'development';
+export const FRONTEND_VERSION = '05';
+
+export const sampleSearchResults: SearchResult[] = [
+  {
+    type: 'river',
+    id: 1,
+    lat: '38.8951',
+    lon: '-77.0364',
+    name: 'Spree',
+  },
+  {
+    type: 'mountain',
+    id: 2,
+    lat: '99.9551',
+    lon: '11.1432',
+    name: 'Brocken',
+  },
+  {
+    type: 'river',
+    id: 3,
+    lat: '12.1233',
+    lon: '57.0123',
+    name: 'Elbe',
+  },
+];

--- a/src/frontend/lib/fetcher.ts
+++ b/src/frontend/lib/fetcher.ts
@@ -1,0 +1,4 @@
+export const fetcher = async (input: RequestInfo, init: RequestInit) => {
+  const res = await fetch(input, init);
+  return res.json();
+};

--- a/src/frontend/lib/types/search.ts
+++ b/src/frontend/lib/types/search.ts
@@ -1,7 +1,7 @@
 export type SearchError = {
   type: string;
   message: string;
-  trace: string;
+  trace?: string;
 };
 
 export type SearchResult = {

--- a/src/frontend/next.config.js
+++ b/src/frontend/next.config.js
@@ -11,6 +11,9 @@ module.exports = {
         ]
       : [];
   },
+  env: { 
+    ENVIRONMENT: process.env.ENVIRONMENT,
+  },
   reactStrictMode: true,
   swcMinify: false,
 };

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -8,10 +8,13 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@headlessui/react": "^1.4.2",
+    "@heroicons/react": "^1.0.5",
     "jotai": "^1.4.3",
     "next": "12.0.1",
     "react": "17.0.2",
-    "react-dom": "17.0.2"
+    "react-dom": "17.0.2",
+    "swr": "^1.0.1"
   },
   "devDependencies": {
     "@types/node": "16.11.6",

--- a/src/frontend/pages/index.tsx
+++ b/src/frontend/pages/index.tsx
@@ -1,20 +1,15 @@
-import type { NextPage } from "next";
-import Head from "next/head";
-import SearchView from "../components/SearchView";
+import type { NextPage } from 'next';
+import React from 'react';
+import SearchView from '@components/SearchView';
+import Layout from '@components/Layout';
 
 const Home: NextPage = () => {
   return (
-    <div>
-      <Head>
-        <title>Geo Data Search</title>
-      </Head>
+    <Layout>
+      <h1 className="text-3xl font-bold">Geo Data Search</h1>
 
-      <main className='container max-w-xl w-full mx-auto my-12'>
-        <h1 className='text-3xl font-bold'>Geo Data Search</h1>
-        
-        <SearchView />
-      </main>
-    </div>
+      <SearchView />
+    </Layout>
   );
 };
 

--- a/src/frontend/styles/globals.css
+++ b/src/frontend/styles/globals.css
@@ -1,3 +1,7 @@
+*:focus:not(:focus-visible) {
+  outline: none;
+}
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/src/frontend/yarn.lock
+++ b/src/frontend/yarn.lock
@@ -107,6 +107,16 @@
   resolved "https://registry.yarnpkg.com/@hapi/hoek/-/hoek-9.2.1.tgz#9551142a1980503752536b5050fd99f4a7f13b17"
   integrity sha512-gfta+H8aziZsm8pZa0vj04KO6biEiisppNgA1kbJvFrrWu9Vm7eaUEy76DIxsuTaWvti5fkJVhllWc6ZTE+Mdw==
 
+"@headlessui/react@^1.4.2":
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/@headlessui/react/-/react-1.4.2.tgz#87e264f190dbebbf8dfdd900530da973dad24576"
+  integrity sha512-N8tv7kLhg9qGKBkVdtg572BvKvWhmiudmeEpOCyNwzOsZHCXBtl8AazGikIfUS+vBoub20Fse3BjawXDVPPdug==
+
+"@heroicons/react@^1.0.5":
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/@heroicons/react/-/react-1.0.5.tgz#2fe4df9d33eb6ce6d5178a0f862e97b61c01e27d"
+  integrity sha512-UDMyLM2KavIu2vlWfMspapw9yii7aoLwzI2Hudx4fyoPwfKfxU8r3cL8dEBXOjcLG0/oOONZzbT14M1HoNtEcg==
+
 "@humanwhocodes/config-array@^0.5.0":
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.5.0.tgz#1407967d4c6eecd7388f83acf1eaf4d0c6e58ef9"
@@ -1021,6 +1031,11 @@ depd@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
   integrity sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=
+
+dequal@2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/dequal/-/dequal-2.0.2.tgz#85ca22025e3a87e65ef75a7a437b35284a7e319d"
+  integrity sha512-q9K8BlJVxK7hQYqa6XISGmBZbtQQWVXSrRrWreHC94rMt1QL/Impruc+7p2CYSYuVIUr+YCt6hjrs1kkdJRTug==
 
 des.js@^1.0.0:
   version "1.0.1"
@@ -3233,6 +3248,13 @@ supports-color@^8.0.0:
   integrity sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==
   dependencies:
     has-flag "^4.0.0"
+
+swr@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/swr/-/swr-1.0.1.tgz#15f62846b87ee000e52fa07812bb65eb62d79483"
+  integrity sha512-EPQAxSjoD4IaM49rpRHK0q+/NzcwoT8c0/Ylu/u3/6mFj/CWnQVjNJ0MV2Iuw/U+EJSd2TX5czdAwKPYZIG0YA==
+  dependencies:
+    dequal "2.0.2"
 
 table@^6.0.9:
   version "6.7.2"


### PR DESCRIPTION
- Shows a list of search results that are received from backend (#84). Due to backend currently still not sending the results, an additional submit button simulates an API response by showing mock results
- Adds about screen with component versions (#96) accessible via a new button in the top right part of the web app. The version of backend and nlp components are requested using a GET API request at the /version endpoints. Results are expected in JSON format, e.g.: `{ result: { backend: "01", nlp: "01"  } }`.
- Adds dev mode available via a new env variable set to `development` (#93): `ENVIRONMENT=development`