### PR TITLE
Bug fixed: not mixing up lat/lng, fixed missing polyline

### DIFF
--- a/src/backend/src/main/java/com/example/backend/controllers/HereApiRestService.java
+++ b/src/backend/src/main/java/com/example/backend/controllers/HereApiRestService.java
@@ -67,6 +67,7 @@ public class HereApiRestService {
         List<ApiResult> listOfPointsAlongTheRoute = new ArrayList<>();
         try {
             hereRoutingAttributes.setReturnTypeToSummary();
+            hereRoutingAttributes.setReturnTypeToPolylineAndTurnByTurnActions();
             String hereApiRoutingResponseString =
                     getRoutingResponse(origin.getCoordinatesAsString(), destination.getCoordinatesAsString(), hereRoutingAttributes);
             logger.debug("HERE / ROUTING / CHARGING STATIONS:");
@@ -78,7 +79,7 @@ public class HereApiRestService {
             chargingStations.addAll(route.getAlLChargingStations());
             String polyline = route.sections.get(0).polyline;
             int i = 1;
-            listOfPointsAlongTheRoute.add(new SingleLocationResult("Start", 0, origin.getName(), origin.getCoordinatesAsString(), polyline));
+            listOfPointsAlongTheRoute.add(new SingleLocationResult("Start", 0, origin.getName(), origin.getLatitude(), origin.getLongitude(), polyline));
             int total = chargingStations.size();
             for (Place chargingStation : chargingStations) {
                 String type = chargingStation.type;
@@ -177,6 +178,15 @@ public class HereApiRestService {
             this.id = id;
             this.lat = lat;
             this.lon = lon;
+            this.name = name;
+            this.polyline = polyline;
+        }
+
+        public SingleLocationResult(String type, int id, String name, double lat, double lon, String polyline) {
+            this.type = type;
+            this.id = id;
+            this.lat = "" + lat;
+            this.lon = "" + lon;
             this.name = name;
             this.polyline = polyline;
         }

--- a/src/backend/src/main/java/com/example/backend/controllers/HereApiRestService.java
+++ b/src/backend/src/main/java/com/example/backend/controllers/HereApiRestService.java
@@ -86,7 +86,8 @@ public class HereApiRestService {
                 String name = "Charging Station " + i + "/" + total;
                 String lat = "" + chargingStation.location.lat;
                 String lng = "" + chargingStation.location.lng;
-                listOfPointsAlongTheRoute.add(new SingleLocationResult(type, i, name, lat, lng));
+                String polylineString = chargingStation.getPolyline();
+                listOfPointsAlongTheRoute.add(new SingleLocationResult(type, i, name, lat, lng, polylineString));
                 i++;
             }
             listOfPointsAlongTheRoute.add(new SingleLocationResult(TYPE_FINISH, i, destination.getName(), destination.getCoordinatesAsString()));

--- a/src/backend/src/main/java/com/example/backend/controllers/HereApiRestService.java
+++ b/src/backend/src/main/java/com/example/backend/controllers/HereApiRestService.java
@@ -66,7 +66,6 @@ public class HereApiRestService {
         RoutingWaypoint destination = hereRoutingAttributes.getDestination();
         List<ApiResult> listOfPointsAlongTheRoute = new ArrayList<>();
         try {
-            hereRoutingAttributes.setReturnTypeToSummary();
             hereRoutingAttributes.setReturnTypeToPolylineAndTurnByTurnActions();
             String hereApiRoutingResponseString =
                     getRoutingResponse(origin.getCoordinatesAsString(), destination.getCoordinatesAsString(), hereRoutingAttributes);

--- a/src/backend/src/main/java/com/example/backend/data/here/Place.java
+++ b/src/backend/src/main/java/com/example/backend/data/here/Place.java
@@ -10,6 +10,7 @@ public class Place implements HereApiElement {
     public Position location;
     @SerializedName("originalLocation")
     public Position originalLocation;
+    private String polyline;
 
     public Place(String type, Position location, Position originalLocation) {
         this.type = type;
@@ -22,6 +23,7 @@ public class Place implements HereApiElement {
                 "\n" + tab + "\ttype = \"" + type + "\"" +
                 "\n" + tab + "\tlocation = " + print(location, tab) +
                 "\n" + tab + "\toriginalLocation = " + print(originalLocation, tab) +
+                "\n" + tab + "\tpolyline = " + polyline +
                 "\n" + tab + "\t}";
     }
 
@@ -31,5 +33,13 @@ public class Place implements HereApiElement {
         } else {
             return "null";
         }
+    }
+
+    public void setPolyline(String polyline) {
+        this.polyline = polyline;
+    }
+
+    public String getPolyline() {
+        return polyline;
     }
 }

--- a/src/backend/src/main/java/com/example/backend/data/here/Route.java
+++ b/src/backend/src/main/java/com/example/backend/data/here/Route.java
@@ -42,6 +42,7 @@ public class Route implements HereApiElement {
         for (Section section : sections) {
             if (section != null && section.departure != null && section.departure.place != null) {
                 if (section.departure.place.type.equals("chargingStation")) {
+                    section.departure.place.setPolyline(section.polyline);
                     allChargingStations.add(section.departure.place);
                 }
             }

--- a/src/backend/src/main/java/com/example/backend/data/http/ResultResponse.java
+++ b/src/backend/src/main/java/com/example/backend/data/http/ResultResponse.java
@@ -6,6 +6,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
 
 import java.util.List;
 
+@SuppressWarnings("StringConcatenationInLoop")
 @ResponseBody
 public class ResultResponse implements HttpResponse {
 
@@ -44,13 +45,18 @@ public class ResultResponse implements HttpResponse {
             output += "NULL";
         } else {
             for (ApiResult singleResult : result) {
+                String polyline = singleResult.getPolyline();
+                if (!singleResult.getPolyline().isEmpty()) {
+                    polyline = polyline.substring(0, (10 % polyline.length()));
+                    polyline += "... REST PRINTED IN DEBUG LOGGING MODE";
+                }
                 output += "\n\t{";
                 output += "type=" + singleResult.getType() + ", ";
                 output += "name=" + singleResult.getName() + ", ";
                 output += "id=" + singleResult.getId() + ", ";
                 output += "lat=" + singleResult.getLat() + ", ";
                 output += "lon=" + singleResult.getLon() + ", ";
-                output += "polyline=ONLY PRINTED IN DEBUG LOGGING";
+                output += "polyline=" + polyline;
                 output += "}";
             }
         }


### PR DESCRIPTION
closes #218 
When searching for route including charging stations: Latitude/Longitude not longer mixed up, and the starting point now contains the polyline.